### PR TITLE
Update to build with Rust 1.0.0-nightly

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1037,7 +1037,7 @@ fn get_radix_base(radix: usize) -> (DoubleBigDigit, usize) {
 }
 
 /// A Sign is a `BigInt`'s composing element.
-#[derive(PartialEq, PartialOrd, Eq, Ord, Copy, Clone, Show, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum Sign { Minus, NoSign, Plus }
 
 impl Neg for Sign {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,12 @@
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
 
-#![feature(slicing_syntax, core)]
+#![feature(slicing_syntax, collections, core, hash, rand, std_misc)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/num/",
        html_playground_url = "http://play.rust-lang.org/")]
-
-#![allow(unstable)]
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
 
-#![feature(slicing_syntax)]
+#![feature(slicing_syntax, core)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
@@ -54,6 +54,7 @@
 #![allow(unstable)]
 
 extern crate "rustc-serialize" as rustc_serialize;
+extern crate core;
 
 pub use bigint::{BigInt, BigUint};
 pub use rational::{Rational, BigRational};


### PR DESCRIPTION
This is a minimal set of changes to fix build errors and warnings.  More work could be done to convert other methods from Option to Result, and to use more error chaining.