### PR TITLE
Upgrade to latest Rust

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -163,8 +163,8 @@ impl Default for BigUint {
     fn default() -> BigUint { Zero::zero() }
 }
 
-impl<S: hash::Hasher + hash::Writer> hash::Hash<S> for BigUint {
-    fn hash(&self, state: &mut S) {
+impl hash::Hash for BigUint {
+    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
         // hash 0 in case it's all 0's
         0u32.hash(state);
 
@@ -366,7 +366,7 @@ impl<'a, 'b> Sub<&'b BigUint> for &'a BigUint {
         let zeros = ZERO_VEC.iter().cycle();
         let (a, b) = (self.data.iter().chain(zeros.clone()), other.data.iter().chain(zeros));
 
-        let mut borrow = 0is;
+        let mut borrow = 0isize;
         let diff: Vec<BigDigit> =  a.take(new_len).zip(b).map(|(ai, bi)| {
             let (hi, lo) = big_digit::from_doublebigdigit(
                 big_digit::BASE
@@ -780,9 +780,9 @@ fn to_str_radix(me: &BigUint, radix: u32) -> String {
     assert!(1 < radix && radix <= 16, "The radix must be within (1, 16]");
     let (base, max_len) = get_radix_base(radix);
     if base == big_digit::BASE {
-        return fill_concat(&me.data[], radix, max_len)
+        return fill_concat(&me.data, radix, max_len)
     }
-    return fill_concat(&convert_base(me, base)[], radix, max_len);
+    return fill_concat(&convert_base(me, base), radix, max_len);
 
     fn convert_base(n: &BigUint, base: DoubleBigDigit) -> Vec<BigDigit> {
         let divider    = base.to_biguint().unwrap();
@@ -807,7 +807,7 @@ fn to_str_radix(me: &BigUint, radix: u32) -> String {
         for n in v.iter().rev() {
             let ss = fmt::radix(*n as usize, radix as u8).to_string();
             s.extend(repeat("0").take(l - ss.len()));
-            s.push_str(&ss[]);
+            s.push_str(&ss);
         }
         s.trim_left_matches('0').to_string()
     }
@@ -969,7 +969,7 @@ impl BigUint {
         if n_unit == 0 || self.is_zero() { return (*self).clone(); }
 
         let mut v = repeat(ZERO_BIG_DIGIT).take(n_unit).collect::<Vec<_>>();
-        v.push_all(&self.data[]);
+        v.push_all(&self.data);
         BigUint::new(v)
     }
 
@@ -1107,8 +1107,8 @@ impl fmt::Display for BigInt {
     }
 }
 
-impl<S: hash::Hasher + hash::Writer> hash::Hash<S> for BigInt {
-    fn hash(&self, state: &mut S) {
+impl hash::Hash for BigInt {
+    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
         (self.sign == Plus).hash(state);
         self.data.hash(state);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,9 @@
 //! ```
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
-
-#![feature(collections, core, hash, std_misc)]
-#![cfg_attr(test, deny(warnings))]
-#![cfg_attr(test, feature(test))]
+#![feature(collections, core, std_misc)]
+//#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(test, feature(hash, test))]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/num/",
@@ -141,6 +140,6 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
 }
 
 #[cfg(test)]
-fn hash<T: hash::Hash<hash::SipHasher>>(x: &T) -> u64 {
-    hash::hash::<_, hash::SipHasher>(x)
+fn hash<T: hash::Hash>(x: &T) -> u64 {
+    hash::hash::<T, hash::SipHasher>(x)
 }

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -759,7 +759,7 @@ mod test {
     #[test]
     fn test_to_from_str() {
         fn test(r: Rational, s: String) {
-            assert_eq!(FromStr::from_str(&s[]), Ok(r));
+            assert_eq!(FromStr::from_str(&s), Ok(r));
             assert_eq!(r.to_string(), s);
         }
         test(_1, "1".to_string());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -70,13 +70,13 @@ macro_rules! zero_impl {
     }
 }
 
-zero_impl!(usize, 0us);
+zero_impl!(usize, 0usize);
 zero_impl!(u8,   0u8);
 zero_impl!(u16,  0u16);
 zero_impl!(u32,  0u32);
 zero_impl!(u64,  0u64);
 
-zero_impl!(isize, 0is);
+zero_impl!(isize, 0isize);
 zero_impl!(i8,  0i8);
 zero_impl!(i16, 0i16);
 zero_impl!(i32, 0i32);
@@ -114,13 +114,13 @@ macro_rules! one_impl {
     }
 }
 
-one_impl!(usize, 1us);
+one_impl!(usize, 1usize);
 one_impl!(u8,  1u8);
 one_impl!(u16, 1u16);
 one_impl!(u32, 1u32);
 one_impl!(u64, 1u64);
 
-one_impl!(isize, 1is);
+one_impl!(isize, 1isize);
 one_impl!(i8,  1i8);
 one_impl!(i16, 1i16);
 one_impl!(i32, 1i32);


### PR DESCRIPTION
Fixes compiler errors as of ~~latest nightly~~ Alpha 2.

There remain several warnings and it was necessary to comment out `#![cfg_attr(test, deny(warnings))]` on the crate as I wasn't sure of the best approach to fix this.

All tests pass on my machine.