### PR TITLE
rustc-serialize is now rustc_serialize

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -58,7 +58,7 @@
 //! # }
 //! ```
 
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 
 use Integer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! approximate a square root to arbitrary precision:
 //!
 //! ```
-//! # #![allow(unstable)]
+//! # #![feature(core)]
 //! extern crate num;
 //!
 //! use std::num::FromPrimitive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
        html_root_url = "http://doc.rust-lang.org/num/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 extern crate core;
 extern crate rand;
 


### PR DESCRIPTION
Fixes build error in Rust nightly.