### PR TITLE
Removed deprecation attributes that can no longer be used outside of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "num"
-version = "0.1.22"
+version = "0.1.23"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/rust-lang/num"

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -691,7 +691,6 @@ impl Integer for BigUint {
     fn lcm(&self, other: &BigUint) -> BigUint { ((self * other) / self.gcd(other)) }
 
     /// Deprecated, use `is_multiple_of` instead.
-    #[deprecated = "function renamed to `is_multiple_of`"]
     #[inline]
     fn divides(&self, other: &BigUint) -> bool { self.is_multiple_of(other) }
 
@@ -1488,7 +1487,6 @@ impl Integer for BigInt {
     }
 
     /// Deprecated, use `is_multiple_of` instead.
-    #[deprecated = "function renamed to `is_multiple_of`"]
     #[inline]
     fn divides(&self, other: &BigInt) -> bool { return self.is_multiple_of(other); }
 

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -82,7 +82,6 @@ pub trait Integer
     fn lcm(&self, other: &Self) -> Self;
 
     /// Deprecated, use `is_multiple_of` instead.
-    #[deprecated = "function renamed to `is_multiple_of`"]
     fn divides(&self, other: &Self) -> bool;
 
     /// Returns `true` if `other` is a multiple of `self`.
@@ -238,7 +237,6 @@ macro_rules! impl_integer_for_isize {
             }
 
             /// Deprecated, use `is_multiple_of` instead.
-            #[deprecated = "function renamed to `is_multiple_of`"]
             #[inline]
             fn divides(&self, other: &$T) -> bool { return self.is_multiple_of(other); }
 
@@ -416,7 +414,6 @@ macro_rules! impl_integer_for_usize {
             }
 
             /// Deprecated, use `is_multiple_of` instead.
-            #[deprecated = "function renamed to `is_multiple_of`"]
             #[inline]
             fn divides(&self, other: &$T) -> bool { return self.is_multiple_of(other); }
 


### PR DESCRIPTION
Also incremented the crates.io version ready for the next `cargo publish`

This closes #84 