### PR TITLE
Update num-macros to rust nightly

### DIFF
--- a/num-macros/src/lib.rs
+++ b/num-macros/src/lib.rs
@@ -64,7 +64,7 @@ macro_rules! path_std {
 pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
                                       span: Span,
                                       mitem: &MetaItem,
-                                      item: Annotatable,
+                                      item: &Annotatable,
                                       push: &mut FnMut(Annotatable))
 {
     let inline = cx.meta_word(span, InternedString::new("inline"));


### PR DESCRIPTION
Now compiles with `rustc 1.2.0-nightly (0fc0476e6 2015-05-24) (built 2015-05-23)`