### PR TITLE
Re-export `cast` for ergonomic reasons

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use integer::Integer;
 pub use iter::{range, range_inclusive, range_step, range_step_inclusive};
 pub use traits::{Num, Zero, One, Signed, Unsigned, Bounded,
                  Saturating, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv,
-                 PrimInt, Float, ToPrimitive, FromPrimitive, NumCast};
+                 PrimInt, Float, ToPrimitive, FromPrimitive, NumCast, cast};
 
 #[cfg(test)] use std::hash;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1293,7 +1293,7 @@ impl_from_primitive! { f64, to_f64 }
 /// ```
 /// use num;
 ///
-/// let twenty: f32 = num::traits::cast(0x14).unwrap();
+/// let twenty: f32 = num::cast(0x14).unwrap();
 /// assert_eq!(twenty, 20f32);
 /// ```
 ///


### PR DESCRIPTION
Fix for issue #92 