### PR TITLE
Make rustc-serialize, bignum, rational, complex into opt-out features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - |
+    (for feature in '' bigint rational complex; do
+      cargo test --verbose --no-default-features --features="$feature" || exit 1
+    done)
+  - |
     [ $TRAVIS_RUST_VERSION != nightly ] || (
       cargo bench &&
       cargo test --verbose --manifest-path=num-macros/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,15 @@ rational, and complex types.
 """
 
 [dependencies]
-rustc-serialize = "0.3.13"
-rand = "0.3.8"
+rustc-serialize = { version = "0.3.13", optional = true }
+rand = { version = "0.3.8", optional = true }
+
+[features]
+
+complex = []
+rational = []
+bigint = ["rustc-serialize", "rand"]
+default = ["complex", "rational", "bigint"]
 
 [[bench]]
 name = "shootout-pidigits"

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -58,8 +58,6 @@
 //! # }
 //! ```
 
-extern crate rustc_serialize;
-
 use Integer;
 
 use std::default::Default;

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -20,7 +20,8 @@ use {Zero, One, Num, Float};
 // probably doesn't map to C's _Complex correctly.
 
 /// A complex number in Cartesian form.
-#[derive(PartialEq, Copy, Clone, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(PartialEq, Copy, Clone, Hash, Debug)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Complex<T> {
     /// Real portion of the complex number
     pub re: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //!
 //! ```
 //! extern crate num;
+//! # #[cfg(all(feature = "bigint", feature="rational"))]
+//! # pub mod test {
 //!
 //! use num::FromPrimitive;
 //! use num::bigint::BigInt;
@@ -35,10 +37,14 @@
 //!
 //!     approx
 //! }
+//! # }
+//! # #[cfg(not(all(feature = "bigint", feature="rational")))]
+//! # fn approx_sqrt(n: u64, _: usize) -> u64 { n }
 //!
 //! fn main() {
 //!     println!("{}", approx_sqrt(10, 4)); // prints 4057691201/1283082416
 //! }
+//!
 //! ```
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
@@ -47,11 +53,18 @@
        html_root_url = "http://doc.rust-lang.org/num/",
        html_playground_url = "http://play.rust-lang.org/")]
 
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+#[cfg(feature = "rand")]
 extern crate rand;
 
+#[cfg(feature = "bigint")]
 pub use bigint::{BigInt, BigUint};
-pub use rational::{Rational, BigRational};
+#[cfg(feature = "rational")]
+pub use rational::Rational;
+#[cfg(all(feature = "rational", feature="bigint"))]
+pub use rational::BigRational;
+#[cfg(feature = "complex")]
 pub use complex::Complex;
 pub use integer::Integer;
 pub use iter::{range, range_inclusive, range_step, range_step_inclusive};
@@ -63,11 +76,13 @@ pub use traits::{Num, Zero, One, Signed, Unsigned, Bounded,
 
 use std::ops::{Mul};
 
+#[cfg(feature = "bigint")]
 pub mod bigint;
 pub mod complex;
 pub mod integer;
 pub mod iter;
 pub mod traits;
+#[cfg(feature = "rational")]
 pub mod rational;
 
 /// Returns the additive identity, `0`.


### PR DESCRIPTION
Make rustc-serialize, bignum, rational, complex into opt-out features

Making bignum optional allows skipping the rustc-serialize and rand
dependencies too, and it makes a big difference in num's build time.

With default (all) features, clean build time including dependencies: 27
seconds.

With no default features, clean build time including dependencies (none):
5 seconds.

Fixes #63