### PR TITLE
Remove reduntant Num trait from an impl.

### DIFF
--- a/src/complex.rs
+++ b/src/complex.rs
@@ -81,9 +81,6 @@ impl<T: Clone + Float> Complex<T> {
     pub fn norm(&self) -> T {
         self.re.clone().hypot(self.im.clone())
     }
-}
-
-impl<T: Clone + Float + Num> Complex<T> {
     /// Calculate the principal Arg of self.
     #[inline]
     pub fn arg(&self) -> T {


### PR DESCRIPTION
Correct me if I'm wrong, but since the ```Float``` trait is defined as ```pub trait Float: Num + other_traits```, having ```impl<T: Clone + Float + Num> Complex<T>``` is not necessary and could be replaced with ```impl<T: Clone + Float> Complex<T>```.

I've moved the functions that are currently in the implementation of ```Complex<T: Clone + Float + Num>```, namely

- ```fn arg(&self) -> T```
- ```fn to_polar(&self) -> (T, T)```
- ```fn from_polar(r: &T, theta: &T) -> Complex<T>```

to the implementation of ```Complex<T: Clone + Float>```. Everything still builds/passes the tests.